### PR TITLE
Fixup the attributes for image directories

### DIFF
--- a/docs/architecture/architecture_notebook.adoc
+++ b/docs/architecture/architecture_notebook.adoc
@@ -186,6 +186,11 @@ https://www2.htw-dresden.de/~anke/openup/core.tech.common.extend_supp/guidances/
 
 Die logische Sicht enthält alle Softwarekomponenten und ihre Abhängigkeiten zueinander. Man kann hier unter anderem erkennen, dass der Pilot das Zentrum der Sicht markiert. Durch das Terminal werden Flugsessions erzeugt, welche die Beziehung zwischen Pilot und Protokoll herstellen.
 
+//:docs-requirements: ../requirements
+//:docs-architecture: ../architecture
+ifndef::docs-requirements[:docs-requirements: ../requirements]
+ifndef::docs-architecture[:docs-architecture: ../architecture]
+
 .Domainmodell
 :imagesdir: {docs-requirements}/images/Domainmodell
 image::domain_model.png[Domainmodell, width=70%, align="center"]

--- a/docs/requirements/use_case_01.inc.adoc
+++ b/docs/requirements/use_case_01.inc.adoc
@@ -1,4 +1,4 @@
-:imagesdir: images/Einzelne_Statusmeldungen
+ifndef::imagesdir[:imagesdir: images]
 == Use-Case: UC01 Pilot anmelden
 ===	Kurzbeschreibung
 
@@ -55,8 +55,8 @@ Bei erfolgreicher Durchführung des Use Case müssen folgende Nachbedingungen er
 === Statusmeldung
 
 .Statusmeldung: S1
-image::UC01_S1.png[S1, width=70%, align="center"]
+image::Einzelne_Statusmeldungen/UC01_S1.png[S1, width=70%, align="center"]
 
 .Statusmeldung: S3
-image::UC01_S3.png[S3, width=70%, align="center"]
+image::Einzelne_Statusmeldungen/UC01_S3.png[S3, width=70%, align="center"]
 

--- a/docs/requirements/use_case_02.inc.adoc
+++ b/docs/requirements/use_case_02.inc.adoc
@@ -1,4 +1,3 @@
-:imagesdir: images/Einzelne_Statusmeldungen
 == Use-Case: UC02 Pilot abmelden
 ===	Kurzbeschreibung
 In diesem Use-Case wird der komplette Vorgang der Abmeldung eines *Piloten* beim Verlassen des Flugplatzes beschrieben.
@@ -41,4 +40,4 @@ Bei erfolgreicher Durchführung des Use Case müssen folgende Nachbedingungen er
 === Statusmeldung
 
 .Statusmeldung: S2
-image::UC02_S2.png[S2, width=70%, align="center"]
+image::Einzelne_Statusmeldungen/UC02_S2.png[S2, width=70%, align="center"]

--- a/docs/requirements/use_case_03.inc.adoc
+++ b/docs/requirements/use_case_03.inc.adoc
@@ -1,4 +1,3 @@
-:imagesdir: images/Wireframes/Verwaltung
 == Use-Case: UC03: Pilotendaten anlegen
 
 ===	Kurzbeschreibung
@@ -61,6 +60,6 @@ Diese Vorkehrungen sind notwendig, wenn sie nicht die Performance des _Webserver
 === Wireframe
 
 .Wireframe: Pilotendaten anlegen
-image::Pilot_Erstellen_V3.png[Pilotendaten anlegen, width=70%, align="center"]
+image::Wireframes/Verwaltung/Pilot_Erstellen_V3.png[Pilotendaten anlegen, width=70%, align="center"]
 
 

--- a/docs/requirements/use_case_04.inc.adoc
+++ b/docs/requirements/use_case_04.inc.adoc
@@ -1,4 +1,3 @@
-:imagesdir: images/Wireframes/Verwaltung
 == Use-Case: UC04: Pilot deaktivieren
 ===	Kurzbeschreibung
 In diesem Use-Case wird der komplette Vorgang zum Deaktivieren eines `Piloten` durch den *Administrator* beschrieben.
@@ -33,5 +32,5 @@ Bei erfolgreicher Durchführung des Use Case müssen folgende Nachbedingungen er
 === Wireframe
 
 .Wireframe: Piloten deaktivieren
-image::Mitglieder_Uebersicht_V3.png[Piloten deaktivieren, width=70%, align="center"]
+image::Wireframes/Verwaltung/Mitglieder_Uebersicht_V3.png[Piloten deaktivieren, width=70%, align="center"]
 

--- a/docs/requirements/use_case_05.inc.adoc
+++ b/docs/requirements/use_case_05.inc.adoc
@@ -1,4 +1,3 @@
-:imagesdir: images/Wireframes/Verwaltung
 == Use-Case: UC05: Pilotendaten modifizieren
 
 ===	Kurzbeschreibung
@@ -34,5 +33,5 @@ Der Akteur "Administrator" möchte die Pilotendaten eines Piloten verändern.
 === Wireframe
 
 .Wireframe: Pilotendaten modifizieren
-image::Pilotendaten_Modifizieren_V3.png[Pilotendaten modifizieren, width=70%, align="center"]
+image::Wireframes/Verwaltung/Pilotendaten_Modifizieren_V3.png[Pilotendaten modifizieren, width=70%, align="center"]
 

--- a/docs/requirements/use_case_06.inc.adoc
+++ b/docs/requirements/use_case_06.inc.adoc
@@ -1,4 +1,3 @@
-:imagesdir: images/Einzelne_Statusmeldungen
 == Use-Case: UC06: Alle Piloten abmelden
 ===	Kurzbeschreibung
 
@@ -52,11 +51,11 @@ Der Use Case gehört zu der erweiterten Funktionalität des Systems und muss dah
 === Statusmeldung
 
 .Statusmeldung: S6
-image::UC06_S6.png[S6, width=70%, align="center"]
+image::Einzelne_Statusmeldungen/UC06_S6.png[S6, width=70%, align="center"]
 
 .Zustand: Kein Pilot aktiv
-image::Zustand_1_Kein_Pilot_aktiv.png[Kein Pilot aktiv, width=70%, align="center"]
+image::Einzelne_Statusmeldungen/Zustand_1_Kein_Pilot_aktiv.png[Kein Pilot aktiv, width=70%, align="center"]
 
 .Zustand: Mindestens 1 Pilot aktiv
-image::Zustand_2_Mindestens_ein_Pilot_aktiv.png[Mindestens 1 Pilot aktiv, width=70%, align="center"]
+image::Einzelne_Statusmeldungen/Zustand_2_Mindestens_ein_Pilot_aktiv.png[Mindestens 1 Pilot aktiv, width=70%, align="center"]
 

--- a/docs/requirements/use_case_07.inc.adoc
+++ b/docs/requirements/use_case_07.inc.adoc
@@ -1,4 +1,3 @@
-:imagesdir: images/Einzelne_Statusmeldungen
 == Use-Case: UC07: Flugleiter bestimmen
 ===	Kurzbeschreibung
 
@@ -48,4 +47,4 @@ Bei erfolgreicher Durchführung des Use Case müssen folgende Nachbedingungen er
 Die Bestimmung eines *Flugleiters* ist prinzipiell ab dem dritten *Piloten* auf dem Flugplatz notwendig. Um jedoch keinen Zwang und somit eine mögliche Ablehnung der *Piloten* gegenüber der Anwesenheitserfassung zu vermeiden, wird die Bestimmung des *Flugleiters* auf freiwilliger Basis bevorzugt.
 
 .Statusmeldung: S4
-image::UC07_S4.png[S4, width=70%, align="center"]
+image::Einzelne_Statusmeldungen/UC07_S4.png[S4, width=70%, align="center"]

--- a/docs/requirements/use_case_08.inc.adoc
+++ b/docs/requirements/use_case_08.inc.adoc
@@ -1,4 +1,3 @@
-:imagesdir: images/Wireframes/Protokoll
 == Use-Case: UC08: Protokoll einsehen
 
 ===	Kurzbeschreibung
@@ -44,5 +43,5 @@ Die Internetverbindung des _Raspis_ bricht ab und aktuelle `Protokolldaten` kön
 === Wireframe
 
 .Wireframe: Protokolldaten
-image::Protkolldaten_einsehen_V3.png[Protokolldaten einsehen, width="70%", align="center"]
+image::Wireframes/Protokoll/Protkolldaten_einsehen_V3.png[Protokolldaten einsehen, width="70%", align="center"]
 

--- a/docs/requirements/use_case_09.inc.adoc
+++ b/docs/requirements/use_case_09.inc.adoc
@@ -1,4 +1,3 @@
-:imagesdir: images/Wireframes/Protokoll
 == Use-Case: UC09: Protokolldaten nachträglich einfügen
 
 ===	Kurzbeschreibung
@@ -43,5 +42,5 @@ Bei erfolgreicher Durchführung des Use Case müssen folgende Nachbedingungen er
 === Wireframe
 
 .Wireframe: Flugzeiten nachtragen
-image::Flugzeit_nachtragen_V3.png[Flugzeiten nachtragen, width=70%, align="center"]
+image::Wireframes/Protokoll/Flugzeit_nachtragen_V3.png[Flugzeiten nachtragen, width=70%, align="center"]
 

--- a/docs/requirements/use_case_11.inc.adoc
+++ b/docs/requirements/use_case_11.inc.adoc
@@ -1,4 +1,3 @@
-:imagesdir: images/Wireframes/Verwaltung
 == Use-Case: UC11: Pilot reaktivieren
 
 ===	Kurzbeschreibung
@@ -41,10 +40,10 @@ Bei erfolgreicher Durchführung des Use Case müssen folgende Nachbedingungen er
 === Wireframe
 
 .Wireframe: Pilotenübersicht (deaktiv)
-image::Piloten_Uebersicht_deaktivierte_Piloten_V3.png[Pilotenübersicht (deaktiv), width=70%, align="center"]
+image::Wireframes/Verwaltung/Piloten_Uebersicht_deaktivierte_Piloten_V3.png[Pilotenübersicht (deaktiv), width=70%, align="center"]
 
 
 .Wireframe: Pilot reaktivieren
-image::Pilotendaten_Reaktivieren_V3.png[Pilot reaktivieren, width=70%, align="center"]
+image::Wireframes/Verwaltung/Pilotendaten_Reaktivieren_V3.png[Pilot reaktivieren, width=70%, align="center"]
 
 


### PR DESCRIPTION
## Allgemein

Bei Asciidoctor muss man unterscheiden, ob man Teile eines Dokumentes in andere Dateien auslagert (Fall 1) oder Dokumente andere Dokumente inkludieren (Fall 2).

Im ersten Falle benötigt man immer das Dokument, welches die ausgelagerten Teile inkludiert, um eine Vorschau zu sehen bzw. das finale Dokument zu generieren.

Im zweiten Falle kann jedes Dokument für sich eine Vorschau zeigen bzw. generiert werden. Wird so ein Dokument in ein übergeordnetes Dokument inkludiert, müssen jetzt die enthaltenen Pfade an die, des übergeordnetes Dokumentes, angepasst werden. Dies ist mit Attributen möglich. Damit jetzt auch die untergeordneten Dokumente für sich funktionieren und sie nicht die benötigten Attribute, des übergeordnetes Dokumentes, überschreiben, muss man die relevanten Attribute mit `ifndef::` anlegen. So kann man prüfen, ob ein Attribut schon in einem übergeordneten Dokument gesetzt wurde.

## Bildpfad in `imagesdir`

Das Problem ist, dass sich das `imagesdir` immer auf den Pfad bezieht, in welchen das Dokument liegt. welches das Bild einbindet.

Wird jetzt das Dokument selbst in einem anderen Dokument eingebunden, verschiebt sich der Pfad, da nun vom neuen Hauptdokument ausgegangen wird.

Bspw.:

```
/docs/document1.adoc
/docs/images/
/docs/test/document2.adoc
/docs/test/images/
```

document1.adoc:
- `:imagesdir: images` -> `/docs/images/`

document2.adoc:
- `:imagesdir: images` -> `/docs/test/images/`

Wird jetzt document2 in document1 inkludiert, werden die Bilder nicht unter `/docs/images/` gefunden. Deswegen kann man vor dem include ein `:imagesdir: test/images` setzen. Muss aber beachten, falls danach noch Bilder für document1 kommen `:imagesdir: images` wieder zurückzusetzen.

## Im Falle des Repositories:

* use_case_01.inc.adoc (`/docs/requirements`)
  -> `images`
* use-case_model.adoc (`/docs/requirements`)
  -> `images`
* se1_belegabgabe_te2.adoc (`/belegabgabe_se1/`)
  -> `../docs/requirements/images`

Das Problem, wenn man in den Dokumenten extra Attribute für die Bildpfade verwendet ist, man muss diese in übergeordneten Dokumenten, welche diese inkludieren, ebenfalls diese Attribute mit den angepassten Pfaden setzen. Damit diese dann aber von dem eigentlichen Dokument nicht wieder überschrieben werden, muss man dafür ein `ifndef::` verwenden. So kann man prüfen, ob in einem übergeordnetem Dokument dieses Attribut schon gesetzt wurde.

se1_belegabgabe_te2.adoc:
- für das Dokument selbst `ifndef::imagesdir[:imagesdir: images]` (über den inklude der Attribute)
- vor dem include des USE Case Modell steht die passende Angabe `:imagesdir: {docs-requirements}/images`

use-case_model.adoc:
- `ifndef::imagesdir[:imagesdir: images]`

use_case_01.inc.adoc:
- `ifndef::imagesdir[:imagesdir: images]`

Da hier die Bilder noch in Unterverzeichnisse unter `images` liegen, würde ich diese direkt beim Bild mit angeben oder wenn man es öfters benötigt in ein Attribut zu dem Dokument unterbringen.

Im `architecture_notebook.adoc` war das Problem ähnlich. Hier wurden die Attribute `{docs-requirements}` und `{docs-architecture}` verwendet, welche in dem Dokument selbst nicht gesetzt waren. Dadurch gingen die Pfade zu den Bildern hier nicht.

Bei den Use_case_XX.adoc Dokumenten ist noch eine Besonderheit. Die Variante mit ausgelagerten Teilen eines Dokumentes. Diese beinhalten ja kein include der Dokumenten-Attribute, sodass hier generell vieles nicht funktioniert. Hier würde man erst beim Anzeigen der use-case_model.adoc Datei die richtige Darstellung sehen. Will man aber trotzdem hier schon bspw. die Bilder sehen, dann könnte man am Anfang ein `ifndef::imagesdir[:imagesdir: images]` einfügen. Alternativ jedes als vollwertiges Document mit Dokumententitel und Attributen bzw. ein include auf `default-attributes.inc.adoc[]` versehen.

Ich habe einen Pull-Request mit den Änderungen erstellt. So könnt ihr euch mal die Änderungen anschauen. Ob ihr es übernehmt (merged) oder von Hand anpasst, könnt ihr entscheiden.